### PR TITLE
Update the backend deployment

### DIFF
--- a/kubernetes/deployments/backend.yaml
+++ b/kubernetes/deployments/backend.yaml
@@ -16,7 +16,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/hov90901/koa-backend:d021bde
-          name: koa-backend
-          ports:
-            - containerPort: 80
+      - image: gcr.io/hov90901/koa-backend:v1
+        name: koa-backend
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This commit updates the backend deployment container image to:

    gcr.io/hov90901/koa-backend:v1

Build ID: 7b896c23-0210-4911-b63d-9b86f73dba6d